### PR TITLE
Cleanup redis rdbcompression

### DIFF
--- a/modules/auxiliary/scanner/redis/file_upload.rb
+++ b/modules/auxiliary/scanner/redis/file_upload.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Auxiliary
     # keys.
     if datastore['DISABLE_RDBCOMPRESSION'] && original_rdbcompression.upcase == 'YES'
       data = redis_command('CONFIG', 'SET', 'rdbcompression', 'no')
-      return unless data.include?('+OK')
+      print_error("#{peer} -- Unable to disable rdbcompresssion") unless data.include?('+OK')
     end
 
     # set a key in this db that contains our content

--- a/modules/auxiliary/scanner/redis/file_upload.rb
+++ b/modules/auxiliary/scanner/redis/file_upload.rb
@@ -18,9 +18,8 @@ class Metasploit3 < Msf::Auxiliary
           achieve somewhat arbitrary file upload to a file and directory to
           which the user account running the redis instance has access.  It is
           not totally arbitrary because the exact contents of the file cannot
-          (yet) be completely controlled.  Depending on the contents of the
-          file that is being uploaded, Redis may compress the data that is
-          ultimately stored in the specified target location.
+          be completely controlled given the nature of how Redis stores its
+          database on disk.
         ),
         'License'       => MSF_LICENSE,
         'Author'        => [
@@ -32,10 +31,7 @@ class Metasploit3 < Msf::Auxiliary
           ['URL', 'http://blog.knownsec.com/2015/11/analysis-of-redis-unauthorized-of-expolit/'],
           ['URL', 'http://redis.io/topics/protocol']
         ],
-        'Platform'      => %w(unix linux),
-        'Targets'       => [['Automatic Target', {}]],
         'Privileged'    => true,
-        'DefaultTarget' => 0,
         'DisclosureDate' => 'Nov 11 2015'
       )
     )
@@ -44,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         OptPath.new('LocalFile', [false, 'Local file to be uploaded']),
         OptString.new('RemoteFile', [false, 'Remote file path']),
-        OptBool.new('DISABLE_RDBCOMPRESSION', [false, 'Disable string compression when dump .rdb databases', true])
+        OptBool.new('DISABLE_RDBCOMPRESSION', [true, 'Disable compression when saving if found to be enabled', true])
       ]
     )
   end
@@ -75,7 +71,6 @@ class Metasploit3 < Msf::Auxiliary
     # If you want to save some CPU in the saving child set it to 'no' but
     # the dataset will likely be bigger if you have compressible values or
     # keys.
-
     if datastore['DISABLE_RDBCOMPRESSION'] && original_rdbcompression.upcase == 'YES'
       data = redis_command('CONFIG', 'SET', 'rdbcompression', 'no')
       return unless data.include?('+OK')


### PR DESCRIPTION
Just a few minor changes to ensure that we only disable when necessary.

re: https://github.com/rapid7/metasploit-framework/pull/6357

I tested this by running it against a default redis instance (which has compression on), and when in `VERBOSE`, I can see it detecting, disabling and finally re-enabling compression.  When compression is disabled, I can see it detecting this and not disabling it or attempting to correct it after the fact.