### PR TITLE
Make Redis command configurable

### DIFF
--- a/modules/auxiliary/scanner/redis/redis_server.rb
+++ b/modules/auxiliary/scanner/redis/redis_server.rb
@@ -26,7 +26,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run_host(_ip)
-    vprint_status("Scanning IP: #{peer}")
+    vprint_status("#{peer} -- contacting redis")
     begin
       connect
       data = redis_command('PING')
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Auxiliary
       print_good("#{peer} -- found redis")
     rescue Rex::AddressInUse, Rex::HostUnreachable, Rex::ConnectionTimeout,
            Rex::ConnectionRefused, ::Timeout::Error, ::EOFError, ::Errno::ETIMEDOUT => e
-      vprint_error("Unable to connect: #{peer} - #{e}")
+      vprint_error("#{peer} -- error while communicating: #{e}")
     ensure
       disconnect
     end

--- a/modules/auxiliary/scanner/redis/redis_server.rb
+++ b/modules/auxiliary/scanner/redis/redis_server.rb
@@ -12,26 +12,33 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'         => 'Redis-server Scanner',
-      'Description'  => %q{
-          This module scans for Redis server. By default Redis has no auth. If auth
-        (password only) is used, it is then possible to execute a brute force attack on
-        the server. This scanner will find open or password protected Redis servers and
-        report back the server information
-      },
+      'Name'         => 'Redis Scanner',
+      'Description'  => %q(
+        This module locates Redis endpoints by attempting to run a specified
+        Redis command.
+      ),
       'Author'       => [ 'iallison <ian[at]team-allison.com>', 'Nixawk' ],
       'License'      => MSF_LICENSE))
 
-    register_options([Opt::RPORT(6379)])
+    register_options(
+      [
+        Opt::RPORT(6379),
+        OptString.new('COMMAND', [ true, 'The Redis command to run', 'INFO' ])
+      ]
+    )
+  end
+
+  def command
+    datastore['COMMAND']
   end
 
   def run_host(_ip)
     vprint_status("#{peer} -- contacting redis")
     begin
       connect
-      data = redis_command('PING')
-      report_service(host: rhost, port: rport, name: "redis server", info: data)
-      print_good("#{peer} -- found redis")
+      return unless (data = redis_command(command))
+      report_service(host: rhost, port: rport, name: "redis server", info: "#{command} response: #{data}")
+      print_good("#{peer} -- found redis with #{command} command: #{Rex::Text.to_hex_ascii(data)}")
     rescue Rex::AddressInUse, Rex::HostUnreachable, Rex::ConnectionTimeout,
            Rex::ConnectionRefused, ::Timeout::Error, ::EOFError, ::Errno::ETIMEDOUT => e
       vprint_error("#{peer} -- error while communicating: #{e}")

--- a/modules/auxiliary/scanner/redis/redis_server.rb
+++ b/modules/auxiliary/scanner/redis/redis_server.rb
@@ -23,8 +23,6 @@ class Metasploit3 < Msf::Auxiliary
       'License'      => MSF_LICENSE))
 
     register_options([Opt::RPORT(6379)])
-
-    deregister_options('RHOST')
   end
 
   def run_host(_ip)


### PR DESCRIPTION
This covers my most recent feedback for https://github.com/rapid7/metasploit-framework/pull/6416 and with this I think it should be landable.

```
msf auxiliary(redis_server) > run

[+] 127.0.0.1:6379 -- found redis with INFO command: $891\x0d\x0aredis_version:2.2.12\x0d\x0aredis_git_sha1:00000000\x0d\x0aredis_git_dirty:0\x0d\x0aarch_bits:64\x0d\x0amultiplexing_api:epoll\x0d\x0aprocess_id:15044\x0d\x0auptime_in_seconds:619\x0d\x0auptime_in_days:0\x0d\x0alru_clock:500503\x0d\x0aused_cpu_sys:0.08\x0d\x0aused_cpu_user:0.11\x0d\x0aused_cpu_sys_children:0.00\x0d\x0aused_cpu_user_children:0.00\x0d\x0aconnected_clients:1\x0d\x0aconnected_slaves:0\x0d\x0aclient_longest_output_list:0\x0d\x0aclient_biggest_input_buf:0\x0d\x0ablocked_clients:0\x0d\x0aused_memory:798864\x0d\x0aused_memory_human:780.14K\x0d\x0aused_memory_rss:1409024\x0d\x0amem_fragmentation_ratio:1.76\x0d\x0ause_tcmalloc:0\x0d\x0aloading:0\x0d\x0aaof_enabled:0\x0d\x0achanges_since_last_save:0\x0d\x0abgsave_in_progress:0\x0d\x0alast_save_time:1452039300\x0d\x0abgrewriteaof_in_progress:0\x0d\x0atotal_connections_received:16\x0d\x0atotal_commands_processed:19\x0d\x0aexpired_keys:0\x0d\x0aevicted_keys:0\x0d\x0akeyspace_hits:0\x0d\x0akeyspace_misses:0\x0d\x0ahash_max_zipmap_entries:512\x0d\x0ahash_max_zipmap_value:64\x0d\x0apubsub_channels:0\x0d\x0apubsub_patterns:0\x0d\x0avm_enabled:0\x0d\x0arole:master
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(redis_server) > set COMMAND PING
COMMAND => PING
msf auxiliary(redis_server) > run

[+] 127.0.0.1:6379 -- found redis with PING command: +PONG
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(redis_server) > 
```