### PR TITLE
Add *args to #respond_to?

### DIFF
--- a/plugins/event_tester.rb
+++ b/plugins/event_tester.rb
@@ -7,6 +7,10 @@ module Msf
 
 class Plugin::EventTester < Msf::Plugin
   class Subscriber
+    def respond_to?(name, *args)
+      # Why yes, I can do that.
+      true
+    end
     def method_missing(name, *args)
       $stdout.puts("Event fired: #{name}(#{args.join(", ")})")
     end


### PR DESCRIPTION
Technically ```include_all = false```, but ```*args``` is lazy mode.

#6523