### PR TITLE
More enum_dns cleanup

### DIFF
--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -361,40 +361,36 @@ class Metasploit3 < Msf::Auxiliary
 
   def get_srv(domain)
     print_status("querying DNS SRV records for #{domain}")
-    srvs = [
-      '_gc._tcp.', '_kerberos._tcp.', '_kerberos._udp.', '_ldap._tcp.',
-      '_test._tcp.',  '_sips._tcp.', '_sip._udp.', '_sip._tcp.',
-      '_aix._tcp.',  '_aix._tcp.', '_finger._tcp.', '_ftp._tcp.',
-      '_http._tcp.', '_nntp._tcp.', '_telnet._tcp.', '_whois._tcp.',
-      '_h323cs._tcp.',  '_h323cs._udp.', '_h323be._tcp.', '_h323be._udp.',
-      '_h323ls._tcp.', '_h323ls._udp.',  '_sipinternal._tcp.',
-      '_sipinternaltls._tcp.', '_sip._tls.', '_sipfederationtls._tcp.',
-      '_jabber._tcp.', '_xmpp-server._tcp.', '_xmpp-client._tcp.',
-      '_imap._tcp.', '_certificates._tcp.',  '_crls._tcp.', '_pgpkeys._tcp.',
-      '_pgprevokations._tcp.', '_cmp._tcp.', '_svcp._tcp.', '_crl._tcp.',
-      '_ocsp._tcp.', '_PKIXREP._tcp.', '_smtp._tcp.', '_hkp._tcp.',
-      '_hkps._tcp.', '_jabber._udp.',  '_xmpp-server._udp.',
-      '_xmpp-client._udp.', '_jabber-client._tcp.', '_jabber-client._udp.']
+    srv_protos = %w(tcp udp tls)
+    srv_record_types = %w(gc kerberos ldap test sips sip aix finger ftp http
+      nntp telnet whois h323cs h323be h323ls sipinternal sipinternaltls sip
+      sipfederationtls jabber jabber-client jabber-server xmpp-server xmpp-client
+      imap certificates crls pgpkeys pgprevokations cmp svcp crl oscp pkixrep
+      smtp hkp hkps)
 
-    records = []
-    srvs.each do |srv|
-      resp = dns_query("#{srv}#{domain}", Net::DNS::SRV)
-      next if resp.blank? || resp.answer.blank?
-      resp.answer.each do |r|
-        next if r.type == Net::DNS::RR::CNAME
+    srv_records = []
+    srv_record_types.each do |srv_record_type|
+      srv_protos.each do |srv_proto|
+        srv_record = "_#{srv_record_type}._#{srv_proto}.#{domain}"
+        resp = dns_query(srv_record, Net::DNS::SRV)
+        next if resp.blank? || resp.answer.blank?
+        srv_record_hosts = []
+        resp.answer.each do |r|
+          next if r.type == Net::DNS::RR::CNAME
+          host = r.host.gsub(/\.$/, '')
+          data = "#{host}:#{r.port}, priority #{r.priority}"
+          print_good("#{srv_record} SRV: #{data}")
+          srv_record_hosts << srv_record
+          srv_records << data
+        end
         report_note(
-          host: domain,
-          proto: 'udp',
-          sname: r.host,
-          port: r.port,
-          type: 'ENUM_SRV',
-          data: "#{r.priority}")
-        print_good("#{domain} : SRV: (Host: #{r.host}, Port: #{r.port}, Priority: #{r.priority})")
+          type: srv_record,
+          data: srv_record_hosts
+        )
       end
     end
-    return if records.blank?
-    save_loot('ENUM_SRV', 'text/plain', domain, "#{records.join(',')}", domain)
-    records
+    return if srv_record_hosts.empty?
+    save_loot('ENUM_SRV', 'text/plain', domain, "#{srv_records.join(',')}", domain)
   end
 
   def axfr(domain)

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -243,7 +243,7 @@ class Metasploit3 < Msf::Auxiliary
       next unless r.class == Net::DNS::RR::NS
       records << "#{r.nsdname}"
       report_host(host: r.nsdname, name: domain, info: 'NS')
-      print_good("#{domain}: NS: #{r.nsdname}")
+      print_good("#{domain} NS: #{r.nsdname}")
     end
     return if records.blank?
 

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
         OptBool.new('ENUM_SOA', [true, 'Enumerate DNS SOA record', true]),
         OptBool.new('ENUM_TXT', [true, 'Enumerate DNS TXT record', true]),
         OptBool.new('ENUM_RVL', [ true, 'Reverse lookup a range of IP addresses', false]),
-        OptBool.new('ENUM_TLD', [true, 'Perform a TLD expansion by replacing the TLD with the IANA TLD list', true]),
+        OptBool.new('ENUM_TLD', [true, 'Perform a TLD expansion by replacing the TLD with the IANA TLD list', false]),
         OptBool.new('ENUM_SRV', [true, 'Enumerate the most common SRV records', true]),
         OptBool.new('STOP_WLDCRD', [true, 'Stops bruteforce enumeration if wildcard resolution is detected', false]),
         OptBool.new('STORE_LOOT', [true, 'Store acquired DNS records as loot', true]),

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -186,7 +186,7 @@ class Metasploit3 < Msf::Auxiliary
                 filename = nil, info = nil, service = nil)
     return unless datastore['STORE_LOOT']
     path = store_loot(ltype, ctype, host, data, filename, info, service)
-    print_good('saved file to: ' + path)
+    vprint_status("Saved #{ltype} loot to #{path}")
   end
 
   def get_ptr(ip)


### PR DESCRIPTION
This fixes some minor output issues and also partially addresses issues with SRV records.  Remember, a given host or host+endpoint can only have one note per `type`.  The code was previously squashing all but the final SRV record.  