### PR TITLE
More enum_dns cleanup

### DIFF
--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -1214,6 +1214,7 @@ module Net # :nodoc:
                 end
                 if block_given?
                   yield [buffer,["",@config[:port],ns.to_s,ns.to_s]]
+                  break
                 else
                   return [buffer,["",@config[:port],ns.to_s,ns.to_s]]
                 end

--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -1031,8 +1031,9 @@ module Net # :nodoc:
           @logger.info "Received #{ans[0].size} bytes from #{ans[1][2]+":"+ans[1][1].to_s}"
 
           begin
-            response = Net::DNS::Packet.parse(ans[0],ans[1])
-            if response && response.answer && response.answer[0] && response.answer[0].type == "SOA"
+            return unless (response = Net::DNS::Packet.parse(ans[0],ans[1]))
+            return if response.answer.empty?
+            if response.answer[0].type == "SOA"
               soa += 1
               if soa >= 2
                 break

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -410,7 +410,7 @@ class Metasploit3 < Msf::Auxiliary
           dns.nameservers -= dns.nameservers
           dns.nameservers = "#{r}"
           zone = dns.axfr(domain)
-        rescue ResolverArgumentError, Errno::ETIMEDOUT, ::NoResponseError, ::Timeout::Error => e
+        rescue ResolverArgumentError, Errno::ECONNREFUSED, Errno::ETIMEDOUT, ::NoResponseError, ::Timeout::Error => e
           print_error("Query #{domain} DNS AXFR - exception: #{e}")
         end
         next if zone.blank?

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -212,6 +212,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def get_cname(domain)
+    print_status("querying DNS CNAME records for #{domain}")
     resp = dns_query(domain, 'CNAME')
     return if resp.blank? || resp.answer.blank?
 
@@ -226,6 +227,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def get_ns(domain)
+    print_status("querying DNS NS records for #{domain}")
     resp = dns_query(domain, 'NS')
     return if resp.blank? || resp.answer.blank?
 
@@ -242,6 +244,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def get_mx(domain)
+    print_status("querying DNS MX records for #{domain}")
     begin
       resp = dns_query(domain, 'MX')
       return if resp.blank? || resp.answer.blank?
@@ -262,6 +265,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def get_soa(domain)
+    print_status("querying DNS SOA records for #{domain}")
     resp = dns_query(domain, 'SOA')
     return if resp.blank? || resp.answer.blank?
 
@@ -277,6 +281,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def get_txt(domain)
+    print_status("querying DNS TXT records for #{domain}")
     resp = dns_query(domain, 'TXT')
     return if resp.blank? || resp.answer.blank?
 
@@ -389,6 +394,7 @@ class Metasploit3 < Msf::Auxiliary
     return if nameservers.blank?
     records = []
     nameservers.each do |nameserver|
+      print_status("Attempting DNS AXFR for #{domain} from #{nameserver}")
       dns = Net::DNS::Resolver.new
       dns.use_tcp = datastore['TCP_DNS']
       dns.udp_timeout = datastore['TIMEOUT']

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -43,7 +43,6 @@ class Metasploit3 < Msf::Auxiliary
         OptBool.new('ENUM_TLD', [true, 'Perform a TLD expansion by replacing the TLD with the IANA TLD list', false]),
         OptBool.new('ENUM_SRV', [true, 'Enumerate the most common SRV records', true]),
         OptBool.new('STOP_WLDCRD', [true, 'Stops bruteforce enumeration if wildcard resolution is detected', false]),
-        OptBool.new('STORE_LOOT', [true, 'Store acquired DNS records as loot', true]),
         OptAddress.new('NS', [false, 'Specify the nameserver to use for queries (default is system DNS)']),
         OptAddressRange.new('IPRANGE', [false, "The target address range or CIDR identifier"]),
         OptInt.new('THREADS', [false, 'Threads for ENUM_BRT', 1]),
@@ -182,13 +181,6 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
-  def save_loot(ltype, ctype, host, data,
-                filename = nil, info = nil, service = nil)
-    return unless datastore['STORE_LOOT']
-    path = store_loot(ltype, ctype, host, data, filename, info, service)
-    vprint_status("Saved #{ltype} loot to #{path}")
-  end
-
   def get_ptr(ip)
     resp = dns_query(ip, nil)
     return if resp.blank? || resp.answer.blank?
@@ -230,7 +222,6 @@ class Metasploit3 < Msf::Auxiliary
       print_good("#{domain}: CNAME: #{r.cname}")
     end
     return if records.blank?
-    save_loot('ENUM_CNAME', domain, 'text/plain', domain, "#{records.join(',')}", domain)
     records
   end
 
@@ -247,7 +238,6 @@ class Metasploit3 < Msf::Auxiliary
     end
     return if records.blank?
 
-    save_loot('ENUM_NS', 'text/plain', domain, "#{records.join(',')}", domain)
     records
   end
 
@@ -267,7 +257,6 @@ class Metasploit3 < Msf::Auxiliary
       print_error("Query #{domain} DNS MX - exception: #{e}")
     ensure
       return if records.blank?
-      save_loot('ENUM_MX', 'text/plain', domain, "#{records.join(',')}", domain)
       records
     end
   end
@@ -284,7 +273,6 @@ class Metasploit3 < Msf::Auxiliary
       print_good("#{domain}: SOA: #{r.mname}")
     end
     return if records.blank?
-    save_loot('ENUM_SOA', 'text/plain', domain, "#{records.join(',')}", domain)
     records
   end
 
@@ -299,7 +287,6 @@ class Metasploit3 < Msf::Auxiliary
       print_good("#{domain}: TXT: #{r.txt}")
     end
     return if records.blank?
-    save_loot('ENUM_TXT', 'text/plain', domain, "#{records.join(',')}", domain)
     records
   end
 
@@ -354,7 +341,6 @@ class Metasploit3 < Msf::Auxiliary
         data: records,
         update: :unique
       )
-      save_loot('ENUM_TLD', 'text/plain', domain, "#{records.join(',')}", domain)
       records
     end
   end
@@ -396,7 +382,6 @@ class Metasploit3 < Msf::Auxiliary
       end
     end
     return if srv_records_data.empty?
-    save_loot('ENUM_SRV', 'text/plain', domain, "#{srv_records_data.join(',')}", domain)
   end
 
   def axfr(domain)
@@ -428,7 +413,6 @@ class Metasploit3 < Msf::Auxiliary
       end
     end
     return if records.blank?
-    save_loot('ENUM_AXFR', 'text/plain', domain, "#{records.join(',')}", domain)
     records
   end
 end

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -205,7 +205,7 @@ class Metasploit3 < Msf::Auxiliary
       next unless r.class == Net::DNS::RR::A
       records << "#{r.address}"
       report_host(host: r.address, name: domain, info: 'A')
-      print_good("#{domain}: A: #{r.address} ") if datastore['ENUM_BRT']
+      print_good("#{domain} A: #{r.address} ") if datastore['ENUM_BRT']
     end
     return if records.blank?
     records
@@ -219,7 +219,7 @@ class Metasploit3 < Msf::Auxiliary
     resp.answer.each do |r|
       next unless r.class == Net::DNS::RR::CNAME
       records << r.cname
-      print_good("#{domain}: CNAME: #{r.cname}")
+      print_good("#{domain} CNAME: #{r.cname}")
     end
     return if records.blank?
     records
@@ -251,7 +251,7 @@ class Metasploit3 < Msf::Auxiliary
         next unless r.class == Net::DNS::RR::MX
         records << "#{r.exchange}"
         report_host(host: r.exchange, name: domain, info: 'MX')
-        print_good("#{domain}: MX: #{r.exchange}")
+        print_good("#{domain} MX: #{r.exchange}")
       end
     rescue SocketError => e
       print_error("Query #{domain} DNS MX - exception: #{e}")
@@ -270,7 +270,7 @@ class Metasploit3 < Msf::Auxiliary
       next unless r.class == Net::DNS::RR::SOA
       records << r.mname
       report_host(host: r.mname, info: 'SOA')
-      print_good("#{domain}: SOA: #{r.mname}")
+      print_good("#{domain} SOA: #{r.mname}")
     end
     return if records.blank?
     records
@@ -284,7 +284,7 @@ class Metasploit3 < Msf::Auxiliary
     resp.answer.each do |r|
       next unless r.class == Net::DNS::RR::TXT
       records << r.txt
-      print_good("#{domain}: TXT: #{r.txt}")
+      print_good("#{domain} TXT: #{r.txt}")
     end
     return if records.blank?
     records
@@ -409,7 +409,7 @@ class Metasploit3 < Msf::Auxiliary
         end
         next if zone.blank?
         records << "#{zone}"
-        print_good("#{domain}: Zone Transfer: #{zone}")
+        print_good("#{domain} Zone Transfer: #{zone}")
       end
     end
     return if records.blank?


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/pull/6187/

This fixes SRV record storage, which was completely broken by my last push.  This also removes all loot storage, since loot is specifically designed for data you've taken from a host after getting a session on it.  This also fixes the AXFR code which seemed to take forever and print out useless information.  Note that I have yet to try this on a system that actually allows AXFR.