### PR TITLE
More fixup for #6187

### DIFF
--- a/lib/net/dns/rr.rb
+++ b/lib/net/dns/rr.rb
@@ -8,7 +8,7 @@ require 'net/dns/rr/types'
 require 'net/dns/rr/classes'
 
 
-%w[a ns mx cname txt soa ptr aaaa mr srv].each do |file|
+%w[a ns mx cname txt hinfo soa ptr aaaa mr srv].each do |file|
   require "net/dns/rr/#{file}"
 end
 

--- a/lib/net/dns/rr/hinfo.rb
+++ b/lib/net/dns/rr/hinfo.rb
@@ -62,7 +62,7 @@ module Net
           len = data.unpack("@#{offset} C")[0]
           @cpu = data[offset+1..offset+1+len]
           offset += len+1
-          len = @data.unpack("@#{offset} C")[0]
+          len = data.unpack("@#{offset} C")[0]
           @os = data[offset+1..offset+1+len]
           return offset += len+1
         end

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -354,7 +354,7 @@ class Metasploit3 < Msf::Auxiliary
     print_status("querying DNS SRV records for #{domain}")
     srv_protos = %w(tcp udp tls)
     srv_record_types = %w(gc kerberos ldap test sips sip aix finger ftp http
-      nntp telnet whois h323cs h323be h323ls sipinternal sipinternaltls sip
+      nntp telnet whois h323cs h323be h323ls sipinternal sipinternaltls
       sipfederationtls jabber jabber-client jabber-server xmpp-server xmpp-client
       imap certificates crls pgpkeys pgprevokations cmp svcp crl oscp pkixrep
       smtp hkp hkps)

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -189,7 +189,6 @@ class Metasploit3 < Msf::Auxiliary
     resp.answer.each do |r|
       next unless r.class == Net::DNS::RR::PTR
       records << "#{r.ptr}"
-      report_host(host: ip, name: "#{r.ptr}", info: 'ip reverse')
       print_good("#{ip}: PTR: #{r.ptr} ")
     end
     return if records.blank?
@@ -204,7 +203,6 @@ class Metasploit3 < Msf::Auxiliary
     resp.answer.each do |r|
       next unless r.class == Net::DNS::RR::A
       records << "#{r.address}"
-      report_host(host: r.address, name: domain, info: 'A')
       print_good("#{domain} A: #{r.address} ") if datastore['ENUM_BRT']
     end
     return if records.blank?
@@ -235,7 +233,6 @@ class Metasploit3 < Msf::Auxiliary
     resp.answer.each do |r|
       next unless r.class == Net::DNS::RR::NS
       records << "#{r.nsdname}"
-      report_host(host: r.nsdname, name: domain, info: 'NS')
       print_good("#{domain} NS: #{r.nsdname}")
     end
     return if records.blank?
@@ -253,7 +250,6 @@ class Metasploit3 < Msf::Auxiliary
       resp.answer.each do |r|
         next unless r.class == Net::DNS::RR::MX
         records << "#{r.exchange}"
-        report_host(host: r.exchange, name: domain, info: 'MX')
         print_good("#{domain} MX: #{r.exchange}")
       end
     rescue SocketError => e
@@ -273,7 +269,6 @@ class Metasploit3 < Msf::Auxiliary
     resp.answer.each do |r|
       next unless r.class == Net::DNS::RR::SOA
       records << r.mname
-      report_host(host: r.mname, info: 'SOA')
       print_good("#{domain} SOA: #{r.mname}")
     end
     return if records.blank?


### PR DESCRIPTION
re: https://github.com/rapid7/metasploit-framework/pull/6187

* removes incorrect `report_host` calls
* Improve AXFR support to try to get lookup NS records to AXFR from via the target NS, but as a fallback, use DNS.
* somewhat corrects `HINFO` support when encountered via AXFR

@all3g, the zone-transfer stuff isn't totally working, but is better now.  More testing/refining is necessary.