### PR TITLE
Searchengine subdomains collector

### DIFF
--- a/modules/auxiliary/gather/searchengine_subdomains_collector.rb
+++ b/modules/auxiliary/gather/searchengine_subdomains_collector.rb
@@ -133,6 +133,7 @@ class Metasploit4 < Msf::Auxiliary
     subdomain_ips = []
     dork = "domain:#{domain}"
     results = bing_search(dork)
+    return domains if results.nil? || results.empty?
     results.each do |subdomain|
       next if domains.include?(subdomain)
       next unless subdomain.include?(domain)
@@ -160,6 +161,7 @@ class Metasploit4 < Msf::Auxiliary
     domains = {}
 
     results = bing_search(dork)
+    return domains if results.nil? || results.empty?
     results.each do |subdomain|
       next if domains.include?(subdomain)
       next unless valid?(ip, subdomain)
@@ -177,6 +179,7 @@ class Metasploit4 < Msf::Auxiliary
     subdomain_ips = []
     dork = "domain:#{domain}"
     results = yahoo_search(dork)
+    return domains if results.nil? || results.empty?
     results.each do |subdomain|
       next if domains.include?(subdomain)
       next unless subdomain.include?(domain)
@@ -204,6 +207,7 @@ class Metasploit4 < Msf::Auxiliary
     domains = {}
 
     results = yahoo_search(dork)
+    return domains if results.nil? || results.empty?
     results.each do |subdomain|
       next if domains.include?(subdomain)
       next unless valid?(ip, subdomain)

--- a/modules/auxiliary/gather/searchengine_subdomains_collector.rb
+++ b/modules/auxiliary/gather/searchengine_subdomains_collector.rb
@@ -71,31 +71,36 @@ class Metasploit4 < Msf::Auxiliary
   def bing_search(dork)
     print_status("Searching Bing for subdomains from #{dork}")
     results = []
-    searches = ['1', '51', '101', '151', '201', '251', '301', '351', '401', '451']
-    searches.each do |num|
-      resp = send_request_cgi!(
-        'rhost' => rhost_bing,
-        'rport' => rport_bing,
-        'vhost' => rhost_bing,
-        'method' => 'GET',
-        'uri' => '/search',
-        'vars_get' => {
-          'FROM' => 'HPCNEN',
-          'setmkt' => 'en-us',
-          'setlang' => 'en-us',
-          'first' => num,
-          'q' => dork
+
+    begin
+      searches = ['1', '51', '101', '151', '201', '251', '301', '351', '401', '451']
+      searches.each do |num|
+        resp = send_request_cgi!(
+          'rhost' => rhost_bing,
+          'rport' => rport_bing,
+          'vhost' => rhost_bing,
+          'method' => 'GET',
+          'uri' => '/search',
+          'vars_get' => {
+            'FROM' => 'HPCNEN',
+            'setmkt' => 'en-us',
+            'setlang' => 'en-us',
+            'first' => num,
+            'q' => dork
         })
 
-      next unless resp && resp.code == 200
-      html = resp.get_html_document
-      matches = html.search('cite')
-      matches.each do |match|
-        result = uri2domain(match.text)
-        next unless result
-        result.to_s.downcase!
-        results << result
+        next unless resp && resp.code == 200
+        html = resp.get_html_document
+        matches = html.search('cite')
+        matches.each do |match|
+          result = uri2domain(match.text)
+          next unless result
+          result.to_s.downcase!
+          results << result
+        end
       end
+    rescue ::Exception => e
+      print_error("#{dork} - #{e.message}")
     end
     results
   end
@@ -103,31 +108,36 @@ class Metasploit4 < Msf::Auxiliary
   def yahoo_search(dork)
     print_status("Searching Yahoo for subdomains from #{dork}")
     results = []
-    searches = ["1", "101", "201", "301", "401", "501"]
-    searches.each do |num|
-      resp = send_request_cgi!(
-        'rhost' => rhost_yahoo,
-        'rport' => rport_yahoo,
-        'vhost' => rhost_yahoo,
-        'method' => 'GET',
-        'uri' => '/search',
-        'vars_get' => {
-          'pz' => 100,
-          'p' => dork,
-          'b' => num
+
+    begin
+      searches = ["1", "101", "201", "301", "401", "501"]
+      searches.each do |num|
+        resp = send_request_cgi!(
+          'rhost' => rhost_yahoo,
+          'rport' => rport_yahoo,
+          'vhost' => rhost_yahoo,
+          'method' => 'GET',
+          'uri' => '/search',
+          'vars_get' => {
+            'pz' => 100,
+            'p' => dork,
+            'b' => num
         })
 
-      next unless resp && resp.code == 200
-      html = resp.get_html_document
-      matches = html.search('span[@class=" fz-15px fw-m fc-12th wr-bw lh-15"]')
-      matches.each do |match|
-        result = match.text
-        result = result.split('/')[0]
-        result = result.split(':')[0]
-        next unless result
-        result.to_s.downcase!
-        results << result
+        next unless resp && resp.code == 200
+        html = resp.get_html_document
+        matches = html.search('span[@class=" fz-15px fw-m fc-12th wr-bw lh-15"]')
+        matches.each do |match|
+          result = match.text
+          result = result.split('/')[0]
+          result = result.split(':')[0]
+          next unless result
+          result.to_s.downcase!
+          results << result
+        end
       end
+    rescue ::Exception => e
+      print_error("#{dork} - #{e.message}")
     end
     results
   end

--- a/modules/auxiliary/gather/searchengine_subdomains_collector.rb
+++ b/modules/auxiliary/gather/searchengine_subdomains_collector.rb
@@ -151,11 +151,7 @@ class Metasploit4 < Msf::Auxiliary
     end
 
     return if domains.empty?
-    report_note(
-      host: domain,
-      type: 'Bing Search Subdomains',
-      update: :unique_data,
-      data: domains)
+    report_note(host: domain, type: 'Bing Search Subdomains', update: :unique_data, data: domains)
     domains
   end
 
@@ -172,11 +168,7 @@ class Metasploit4 < Msf::Auxiliary
       domains[subdomain] = ip
     end
     return if domains.empty?
-    report_note(
-      host: ip,
-      type: 'Bing Search Subdomains',
-      update: :unique_data,
-      data: domains)
+    report_note(host: ip, type: 'Bing Search Subdomains', update: :unique_data, data: domains)
     domains
   end
 
@@ -203,11 +195,7 @@ class Metasploit4 < Msf::Auxiliary
     end
 
     return if domains.empty?
-    report_note(
-      host: domain,
-      type: 'Yahoo Search Subdomains',
-      update: :unique_data,
-      data: domains)
+    report_note(host: domain, type: 'Yahoo Search Subdomains', update: :unique_data, data: domains)
     domains
   end
 
@@ -224,11 +212,7 @@ class Metasploit4 < Msf::Auxiliary
       domains[subdomain] = ip
     end
     return if domains.empty?
-    report_note(
-      host: ip,
-      type: 'Yahoo Search Subdomains',
-      update: :unique_data,
-      data: domains)
+    report_note(host: ip, type: 'Yahoo Search Subdomains', update: :unique_data, data: domains)
     domains
   end
 

--- a/modules/auxiliary/gather/searchengine_subdomains_collector.rb
+++ b/modules/auxiliary/gather/searchengine_subdomains_collector.rb
@@ -5,7 +5,7 @@
 
 require 'msf/core'
 
-class Metasploit4 < Msf::Auxiliary
+class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
 

--- a/modules/auxiliary/gather/searchengine_subdomains_collector.rb
+++ b/modules/auxiliary/gather/searchengine_subdomains_collector.rb
@@ -47,13 +47,17 @@ class Metasploit4 < Msf::Auxiliary
   end
 
   def valid?(ip, domain)
+    ips = domain2ip(domain)
+    (ips && ips.include?(ip)) ? true : false
+  end
+
+  def domain2ip(domain)
+    ips = []
     begin
       ips = Rex::Socket.getaddresses(domain)
-      true if ips.include?(ip)
     rescue SocketError
-    ensure
-      false
     end
+    ips
   end
 
   def uri2domain(uri)
@@ -137,7 +141,7 @@ class Metasploit4 < Msf::Auxiliary
     results.each do |subdomain|
       next if domains.include?(subdomain)
       next unless subdomain.include?(domain)
-      ips = Rex::Socket.getaddresses(subdomain)
+      ips = domain2ip(subdomain)
       ips.each do |ip|
         report_host(host: ip, name: subdomain)
         print_good("#{dork} subdomain: #{subdomain} - #{ip}")
@@ -183,7 +187,7 @@ class Metasploit4 < Msf::Auxiliary
     results.each do |subdomain|
       next if domains.include?(subdomain)
       next unless subdomain.include?(domain)
-      ips = Rex::Socket.getaddresses(subdomain)
+      ips = domain2ip(subdomain)
       ips.each do |ip|
         report_host(host: ip, name: subdomain)
         print_good("#{dork} subdomain: #{subdomain} - #{ip}")
@@ -222,6 +226,7 @@ class Metasploit4 < Msf::Auxiliary
 
   def run
     target = datastore['TARGET']
+
     if Rex::Socket.is_ipv4?(target)
       bing_search_ip(target) if datastore['ENUM_BING']
       yahoo_search_ip(target) if datastore['ENUM_YAHOO']

--- a/modules/auxiliary/gather/searchengine_subdomains_collector.rb
+++ b/modules/auxiliary/gather/searchengine_subdomains_collector.rb
@@ -87,7 +87,7 @@ class Metasploit4 < Msf::Auxiliary
             'setlang' => 'en-us',
             'first' => num,
             'q' => dork
-        })
+          })
 
         next unless resp && resp.code == 200
         html = resp.get_html_document
@@ -122,7 +122,7 @@ class Metasploit4 < Msf::Auxiliary
             'pz' => 100,
             'p' => dork,
             'b' => num
-        })
+          })
 
         next unless resp && resp.code == 200
         html = resp.get_html_document
@@ -147,7 +147,7 @@ class Metasploit4 < Msf::Auxiliary
     ipv4 = Rex::Socket.is_ipv4?(target)
     dork = ipv4 ? "ip:#{target}" : "domain:#{target}"
 
-    results = []  # merge results to reduce query times
+    results = [] # merge results to reduce query times
     results |= bing_search(dork) if datastore['ENUM_BING']
     results |= yahoo_search(dork) if datastore['ENUM_YAHOO']
 


### PR DESCRIPTION
- Reduce code
- Handle **yahoo_search** / **bing_search** exception
- **```Class Metasploit4```** -> **```Class MetasploitModule```**

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/searchengine_subdomains_collector`


```
msf auxiliary(searchengine_subdomains_collector) > show options 

Module options (auxiliary/gather/searchengine_subdomains_collector):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   ENUM_BING   true             yes       Enable Bing Search Subdomains
   ENUM_YAHOO  true             yes       Enable Yahoo Search Subdomains
   IP_SEARCH   true             no        Enable ip of subdomains to locate subdomains
   TARGET      baidu.com        yes       The target to locate subdomains for, ex: rapid7.com, 8.8.8.8

msf auxiliary(searchengine_subdomains_collector) > run 

[*] Searching Bing for subdomains from domain:baidu.com
[*] Searching Yahoo for subdomains from domain:baidu.com
[+] domain:baidu.com subdomain: vpn.baidu.com
...

```
